### PR TITLE
Add plain text

### DIFF
--- a/_includes/schedule-plain.html
+++ b/_includes/schedule-plain.html
@@ -1,0 +1,60 @@
+<!-- Begin Schedule Section -->
+<header id="top-header" class="top-header">
+    <div class="overlay white-solid"></div>
+    <a href="{{ site.baseurl }}/" id="logo-header" class="logo-header">
+        <div class="logo logo-light"></div>
+    </a>
+    <nav class="st-menu st-effect" id="menu">
+        <div class="logo-navbar logo logo-dark visible-xs"></div>
+        <ul>
+            {% for navigationLink in site.navigationLinks %}
+            <li>
+                <a class="{% if navigationLink.permalink != null and page.permalink == navigationLink.permalink %}current{% endif %}"  href="{% if navigationLink.permalink != null %} {{ navigationLink.permalink | prepend: site.baseurl }} {% else %} {{ navigationLink.link }} {% endif %}" {% if navigationLink.link != null %}target="_blank"{% endif %}>{{ navigationLink.text}}</a>
+            </li>
+            {% endfor %}
+        </ul>
+        <ul id="bottom-navlinks" class="bottom-navlinks visible-xs">
+            {% for bottomNavigationLink in site.bottomNavigationLinks %}
+            <li>
+                <a href="{% if bottomNavigationLink.permalink != null %} {{ bottomNavigationLink.permalink | prepend: site.baseurl }} {% else %} {{ bottomNavigationLink.link }} {% endif %}" {% if bottomNavigationLink.link != null %}target="_blank"{% endif %}>{{ bottomNavigationLink.text }}</a>
+            </li>
+            {% endfor %}
+        </ul>
+    </nav>
+</header>
+
+<h1>{{page.title}}</h1>
+<h3>Programme</h2>
+    {% for day in site.data.schedule %}
+        {% for timeslot in day.timeslots %}
+            {% assign startTime = timeslot.startTime | split: ":" %}
+
+            {% assign endTime = timeslot.endTime | split: ":" %}
+            {% for slot in timeslot.sessionIds %}
+                {% assign slotColWidth = 12 | divided_by: forloop.length %}
+                {% assign slotIndex = forloop.index0 %}
+                {% for session in site.data.sessions %}
+                    {% if slot == session.id and session.service == null %}
+                        <h3>{{ startTime[0] }}<span>:{{ startTime[1] }}</span>-{{ endTime[0] }}<span>:{{ endTime[1] }}</span> {{ session.title }}</h3>
+                        
+                            {% for session_speaker in session.speakers %}
+                                {% for speaker in site.data.speakers %}
+
+                                    {% if session_speaker == speaker.id %}
+                                        <p>{{ speaker.name }} {{ speaker.surname }}
+                                            <span>{{ speaker.company }}</span>
+                                        </p>
+                                    {% endif %}
+                                {% endfor %}    
+                            {% endfor %}
+                    {% elsif slot == session.id and session.service != null %}
+                        <h3 class="slot-title" itemprop="name">{{ session.title }}</h3>
+                        {% if session.description != null %}
+                            <p class="service-description">{{ session.description }}</p>
+                        {% endif %}
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
+        {% endfor %}
+    {% endfor %}
+<!-- End Schedule Section -->

--- a/_includes/schedule-plain.html
+++ b/_includes/schedule-plain.html
@@ -31,26 +31,53 @@
 
             {% assign endTime = timeslot.endTime | split: ":" %}
             {% for slot in timeslot.sessionIds %}
+                {% assign track = day.tracks[forloop.index0].title %}
                 {% assign slotColWidth = 12 | divided_by: forloop.length %}
                 {% assign slotIndex = forloop.index0 %}
                 {% for session in site.data.sessions %}
                     {% if slot == session.id and session.service == null %}
-                        <h3>{{ startTime[0] }}<span>:{{ startTime[1] }}</span>-{{ endTime[0] }}<span>:{{ endTime[1] }}</span> {{ session.title }}</h3>
-                        
-                            {% for session_speaker in session.speakers %}
-                                {% for speaker in site.data.speakers %}
+                        <hr/>
+                        <h3>{{day.dateReadable}} {{ startTime[0] }}<span>:{{ startTime[1] }}</span>-{{ endTime[0] }}<span>:{{ endTime[1] }}</span> {{ session.title }}</h3>
+                        <h3>{{track}}</h3>
 
-                                    {% if session_speaker == speaker.id %}
-                                        <p>{{ speaker.name }} {{ speaker.surname }}
-                                            <span>{{ speaker.company }}</span>
-                                        </p>
-                                    {% endif %}
-                                {% endfor %}    
+                        {% if session.sessions %}
+
+                            {% for talk in session.sessions %}
+
+                                <h4>{{talk.talkTitle}}</h4>
+                                <strong>Talk time:</strong> {{talk.startTime}}-{{talk.endTime}}<br>
+
+                                <p class="theme-description"><strong>Abstract: </strong>{{ talk.description }}</p>
+                                <div class="people-details">
+                                    {% for speaker in site.data.speakers %}
+                                            {% if talk.speaker == speaker.id %}
+                                                    <p class="name"><strong>Speaker: </strong>{{ speaker.name }} {{ speaker.surname }}{% if speaker.title %},{% endif%} 
+                                                        <span class="position">{% if speaker.title %}  {{ speaker.title }},{% endif%} {{ speaker.company }}</span>
+                                                    </p>
+                                                    {%if speaker.bio %}
+                                                    <p class="about"><strong>Biography: </strong>{{ speaker.bio }}</p>
+                                                    {% endif %}
+                                            {% endif %}
+                                    {% endfor %}
+                                </div>
                             {% endfor %}
-                    {% elsif slot == session.id and session.service != null %}
-                        <h3 class="slot-title" itemprop="name">{{ session.title }}</h3>
-                        {% if session.description != null %}
-                            <p class="service-description">{{ session.description }}</p>
+                        {% else %}
+
+                        {% if session.description %}
+                        <p class="theme-description"><strong>Abstract: </strong>{{ session.description }}</p>
+                        {% endif %}
+                        <div class="people-details">
+                            {% for speaker in site.data.speakers %}
+                                    {% if session.speakers[0] == speaker.id %}
+                                            <p class="name"><strong>Speaker: </strong>{{ speaker.name }} {{ speaker.surname }}{% if speaker.title %},{% endif%} 
+                                                <span class="position">{% if speaker.title %}  {{ speaker.title }},{% endif%} {{ speaker.company }}</span>
+                                            </p>
+                                            {%if speaker.bio %}
+                                            <p class="about"><strong>Biography: </strong>{{ speaker.bio }}</p>
+                                            {% endif %}
+                                    {% endif %}
+                            {% endfor %}
+                        </div>
                         {% endif %}
                     {% endif %}
                 {% endfor %}

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -2,7 +2,7 @@
 <section id="schedule" class="schedule">
     <div class="content-wrapper">
             <h3>Programme</h3>
-            <h5><a href="{{ site.url }}{{ site.baseurl }}/schedule-plain/">View this schedule as plain text</a></h5>
+            <h5 style="font-weight:bold;"><a href="{{ site.url }}{{ site.baseurl }}/schedule-plain/">View this schedule as plain text</a></h5>
         {% for day in site.data.schedule %}
         <div class="schedule-table col-lg-8 col-md-10 col-md-offset-1">
             <h4 class="schedule-table-heading">{{ day.dateReadable }}</h4>

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -2,6 +2,7 @@
 <section id="schedule" class="schedule">
     <div class="content-wrapper">
             <h3>Programme</h3>
+            <h5><a href="{{ site.url }}{{ site.baseurl }}/schedule-plain/">View this schedule as plain text</a></h5>
         {% for day in site.data.schedule %}
         <div class="schedule-table col-lg-8 col-md-10 col-md-offset-1">
             <h4 class="schedule-table-heading">{{ day.dateReadable }}</h4>

--- a/schedule-plain.html
+++ b/schedule-plain.html
@@ -1,0 +1,6 @@
+---
+title: Event schedule - plain text
+permalink: /schedule-plain/
+---
+
+{% include schedule-plain.html %}


### PR DESCRIPTION
This PR introduces a new `schedule-plain` page that contains the schedule rendered in plain text.

